### PR TITLE
allow users to customize requests and formatting of last_updated field

### DIFF
--- a/app/models/blacklight_dynamic_sitemap/sitemap.rb
+++ b/app/models/blacklight_dynamic_sitemap/sitemap.rb
@@ -8,13 +8,14 @@ module BlacklightDynamicSitemap
 
     def get(id)
       index_connection.select(
-        params: {
-          q: "{!prefix f=#{hashed_id_field} v=#{id}}",
+        params: show_params(id, {
+          q: '*:*',
+          fq: ["{!prefix f=#{hashed_id_field} v=#{id}}"],
           fl: [unique_id_field, last_modified_field].join(','),
           rows: 2_000_000, # Ensure that we do not page this result
           facet: false,
           defType: 'lucene'
-        }
+        })
       ).dig('response', 'docs')
     end
 
@@ -23,6 +24,14 @@ module BlacklightDynamicSitemap
     end
 
     private
+
+    def show_params(id, default_params)
+      engine_config.modify_show_params&.call(id, default_params) || default_params
+    end
+
+    def index_params(default_params)
+      engine_config.modify_index_params&.call(default_params) || default_params
+    end
 
     def index_connection
       @index_connection ||= Blacklight.default_index.connection
@@ -34,10 +43,10 @@ module BlacklightDynamicSitemap
 
     def max_documents
       key = 'blacklight_dynamic_sitemap.index_max_docs'
-      expiration = BlacklightDynamicSitemap::Engine.config.max_documents_expiration
+      expiration = engine_config.max_documents_expiration
       Rails.cache.fetch(key, expires_in: expiration) do
-        Blacklight.default_index.connection.select(
-          params: { q: '*:*', rows: 0, facet: false }
+        index_connection.select(
+          params: index_params({ q: '*:*', rows: 0, facet: false })
         )['response']['numFound']
       end
     end

--- a/app/views/blacklight_dynamic_sitemap/sitemap/show.xml.builder
+++ b/app/views/blacklight_dynamic_sitemap/sitemap/show.xml.builder
@@ -6,10 +6,12 @@ xml.urlset(
   'xsi:schemaLocation' => 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd',
   'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9'
 ) do
+  config = BlacklightDynamicSitemap::Engine.config
   @sitemap_entries.each do |doc|
     xml.url do
-      xml.loc(main_app.solr_document_url(doc[BlacklightDynamicSitemap::Engine.config.unique_id_field]))
-      xml.lastmod(doc[BlacklightDynamicSitemap::Engine.config.last_modified_field])
+      xml.loc(main_app.solr_document_url(doc[config.unique_id_field]))
+      last_modified = doc[config.last_modified_field]
+      xml.lastmod(config.format_last_modified&.call(last_modified) || last_modified)
     end
   end
 end

--- a/lib/blacklight_dynamic_sitemap/engine.rb
+++ b/lib/blacklight_dynamic_sitemap/engine.rb
@@ -8,5 +8,8 @@ module BlacklightDynamicSitemap
     config.hashed_id_field = 'hashed_id_ssi'
     config.unique_id_field = 'id'
     config.last_modified_field = 'timestamp'
+    config.modify_show_params = nil # lambda { |id, default_params| default_params }
+    config.modify_index_params = nil # lambda { |default_params| default_params }
+    config.format_last_modified = nil # lambda { |raw_last_modified| raw_last_modified }
   end
 end


### PR DESCRIPTION
Following the pattern established in config/initializers, this provides hooks for some more nuanced customization. An example of how these could be used can be found [here](https://github.com/upenn-libraries/discovery-app/commit/21d978b1f9d4adeff888675922a6f96dbffb9d1f#diff-1dce259df88b747ff15f2ba6066c5ebbfef0abdbc97589603974af69e866526f).