### PR TITLE
support as low as rails v4.2; no reason not to

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ This gem offers several configuration options that can be configured in a Rails 
 
 See [engine.rb](https://github.com/sul-dlss/blacklight_dynamic_sitemap/blob/master/lib/blacklight_dynamic_sitemap/engine.rb) for available configurations.
 
+### Rails version compatibility note
+Note that the gemspec does not list a lower threshold for Rails version compatibility. This gem has been anecdotally demonstrated to work fine as low as Rails 4.2, but maintaining compatibility of the test suite with rails <5.0 was more complex than practical benefits warranted. Exercise caution when using with Rails <5.0.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake ci` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/blacklight_dynamic_sitemap.gemspec
+++ b/blacklight_dynamic_sitemap.gemspec
@@ -24,7 +24,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails', '>= 5.2', '<= 6.1'
+  # Rails <5.0 is not covered by the automated test suite (see `.github/workflows/ruby.yml`).
+  # Anecdotally demonstrated to work fine on Rails as low as 4.2, but any lower version
+  # threshold would be arbitrary.
+  spec.add_dependency 'rails', '<= 6.1'
   spec.add_dependency 'blacklight', '> 6.0'
 
   spec.add_development_dependency 'capybara'


### PR DESCRIPTION
Not sure whether the current lowest supported rails version was intentional or just arbitrary (i.e., "this is what we're on and it works here, but no guarantees wrt lower rails versions").

We're on rails 4.2; this PR replaces one (presumably?) arbitrary lower limit with another _definitely_ arbitrary lower limit :-) ... but there's not much in the way of fancy new stuff being actually used in any of this code, and it works fine for us on rails 4.2. Is there a reason that I'm missing to keep this restricted to 5.2+? In any case, thanks for considering!