### PR TITLE
Provides for more expansive cache configuration options

### DIFF
--- a/app/models/blacklight_dynamic_sitemap/sitemap.rb
+++ b/app/models/blacklight_dynamic_sitemap/sitemap.rb
@@ -47,8 +47,8 @@ module BlacklightDynamicSitemap
 
     def max_documents
       key = 'blacklight_dynamic_sitemap.index_max_docs'
-      expiration = engine_config.max_documents_expiration
-      Rails.cache.fetch(key, expires_in: expiration) do
+      cache_options = engine_config.cache_options
+      Rails.cache.fetch(key, **cache_options) do
         index_connection.select(
           params: index_params({ q: '*:*', rows: 0, facet: false })
         )['response']['numFound']

--- a/lib/blacklight_dynamic_sitemap/engine.rb
+++ b/lib/blacklight_dynamic_sitemap/engine.rb
@@ -3,7 +3,7 @@
 module BlacklightDynamicSitemap
   class Engine < ::Rails::Engine
     isolate_namespace BlacklightDynamicSitemap
-    config.max_documents_expiration = 1.day
+    config.cache_options = { expires_in: 1.day }
     config.minimum_average_chunk = 10_000
     config.hashed_id_field = 'hashed_id_ssi'
     config.unique_id_field = 'id'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ EngineCart.load_application!
 require 'rspec/rails'
 require 'capybara/rspec'
 
+BlacklightDynamicSitemap::Engine.config.cache_options = { force: true }
+
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 


### PR DESCRIPTION
This allows us to control this cache more directly in our test suite (and for adopters). This is a breaking change.